### PR TITLE
Altimeter Test Branch

### DIFF
--- a/karman-avionics/karman-avionics.cproj
+++ b/karman-avionics/karman-avionics.cproj
@@ -138,7 +138,7 @@
       </framework-data>
     </AsfFrameworkConfig>
     <avrtool>com.atmel.avrdbg.tool.atmelice</avrtool>
-    <avrtoolserialnumber>J41800022744</avrtoolserialnumber>
+    <avrtoolserialnumber>J41800026976</avrtoolserialnumber>
     <avrdeviceexpectedsignature>0x1E9842</avrdeviceexpectedsignature>
     <com_atmel_avrdbg_tool_simulator>
       <ToolOptions>
@@ -173,7 +173,7 @@
         <InterfaceName>PDI</InterfaceName>
       </ToolOptions>
       <ToolType>com.atmel.avrdbg.tool.atmelice</ToolType>
-      <ToolNumber>J41800022744</ToolNumber>
+      <ToolNumber>J41800026976</ToolNumber>
       <ToolName>Atmel-ICE</ToolName>
     </com_atmel_avrdbg_tool_atmelice>
     <avrtoolinterfaceclock>4000000</avrtoolinterfaceclock>
@@ -277,103 +277,103 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <ToolchainSettings>
       <AvrGcc>
-  <avrgcc.common.Device>-mmcu=atxmega256a3u -B "%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\gcc\dev\atxmega256a3u"</avrgcc.common.Device>
-  <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
-  <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
-  <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
-  <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
-  <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
-  <avrgcc.compiler.symbols.DefSymbols>
-    <ListValues>
-      <Value>DEBUG</Value>
-      <Value>BOARD=USER_BOARD</Value>
-      <Value>IOPORT_XMEGA_COMPAT</Value>
-      <Value>TEST_SUITE_DEFINE_ASSERT_MACRO</Value>
-      <Value>_ASSERT_ENABLE_</Value>
-    </ListValues>
-  </avrgcc.compiler.symbols.DefSymbols>
-  <avrgcc.compiler.directories.IncludePaths>
-    <ListValues>
-      <Value>../src/ASF/common/boards/user_board</Value>
-      <Value>../src/ASF/common/boards</Value>
-      <Value>../src/ASF/xmega/utils/preprocessor</Value>
-      <Value>../src/ASF/xmega/utils</Value>
-      <Value>../src/ASF/common/utils</Value>
-      <Value>../src</Value>
-      <Value>../src/config</Value>
-      <Value>../src/framework</Value>
-      <Value>../src/utils</Value>
-      <Value>../src/tasks</Value>
-      <Value>../src/drivers</Value>
-      <Value>../src/ASF/xmega/drivers/cpu</Value>
-      <Value>../src/ASF/xmega/drivers/nvm</Value>
-      <Value>../src/ASF/xmega/drivers/pmic</Value>
-      <Value>../src/ASF/xmega/drivers/sleep</Value>
-      <Value>../src/ASF/xmega/drivers/spi</Value>
-      <Value>../src/ASF/xmega/drivers/tc</Value>
-      <Value>../src/ASF/common/services/clock</Value>
-      <Value>../src/ASF/common/services/gpio</Value>
-      <Value>../src/ASF/common/services/ioport</Value>
-      <Value>../src/ASF/common/services/sleepmgr</Value>
-      <Value>../src/ASF/xmega/drivers/twi</Value>
-      <Value>../src/ASF/xmega/drivers/usart</Value>
-      <Value>../src/ASF/common/services/hugemem</Value>
-      <Value>../src/ASF/xmega/drivers/dma</Value>
-      <Value>../src/ASF/common/services/usb</Value>
-      <Value>../src/ASF/common/services/usb/class/cdc</Value>
-      <Value>../src/ASF/common/services/usb/class/cdc/device</Value>
-      <Value>../src/ASF/common/services/usb/udc</Value>
-      <Value>../src/ASF/xmega/drivers/usb</Value>
-      <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
-    </ListValues>
-  </avrgcc.compiler.directories.IncludePaths>
-  <avrgcc.compiler.optimization.level>Optimize debugging experience (-Og)</avrgcc.compiler.optimization.level>
-  <avrgcc.compiler.optimization.OtherFlags>-fdata-sections</avrgcc.compiler.optimization.OtherFlags>
-  <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
-  <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
-  <avrgcc.compiler.optimization.DebugLevel>Maximum (-g3)</avrgcc.compiler.optimization.DebugLevel>
-  <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
-  <avrgcc.compiler.miscellaneous.OtherFlags>-std=gnu99 -fno-strict-aliasing -Wstrict-prototypes -Wmissing-prototypes -Werror-implicit-function-declaration -Wpointer-arith -mrelax</avrgcc.compiler.miscellaneous.OtherFlags>
-  <avrgcc.linker.libraries.Libraries>
-    <ListValues>
-      <Value>libm</Value>
-    </ListValues>
-  </avrgcc.linker.libraries.Libraries>
-  <avrgcc.linker.miscellaneous.LinkerFlags>-Wl,--relax</avrgcc.linker.miscellaneous.LinkerFlags>
-  <avrgcc.assembler.general.AssemblerFlags>-mrelax -DBOARD=USER_BOARD</avrgcc.assembler.general.AssemblerFlags>
-  <avrgcc.assembler.general.IncludePaths>
-    <ListValues>
-      <Value>../src/ASF/common/boards/user_board</Value>
-      <Value>../src/ASF/common/boards</Value>
-      <Value>../src/ASF/xmega/utils/preprocessor</Value>
-      <Value>../src/ASF/xmega/utils</Value>
-      <Value>../src/ASF/common/utils</Value>
-      <Value>../src</Value>
-      <Value>../src/config</Value>
-      <Value>../src/ASF/xmega/drivers/cpu</Value>
-      <Value>../src/ASF/xmega/drivers/nvm</Value>
-      <Value>../src/ASF/xmega/drivers/pmic</Value>
-      <Value>../src/ASF/xmega/drivers/sleep</Value>
-      <Value>../src/ASF/xmega/drivers/spi</Value>
-      <Value>../src/ASF/xmega/drivers/tc</Value>
-      <Value>../src/ASF/common/services/clock</Value>
-      <Value>../src/ASF/common/services/gpio</Value>
-      <Value>../src/ASF/common/services/ioport</Value>
-      <Value>../src/ASF/common/services/sleepmgr</Value>
-      <Value>../src/ASF/xmega/drivers/twi</Value>
-      <Value>../src/ASF/xmega/drivers/usart</Value>
-      <Value>../src/ASF/common/services/hugemem</Value>
-      <Value>../src/ASF/xmega/drivers/dma</Value>
-      <Value>../src/ASF/common/services/usb</Value>
-      <Value>../src/ASF/common/services/usb/class/cdc</Value>
-      <Value>../src/ASF/common/services/usb/class/cdc/device</Value>
-      <Value>../src/ASF/common/services/usb/udc</Value>
-      <Value>../src/ASF/xmega/drivers/usb</Value>
-      <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
-    </ListValues>
-  </avrgcc.assembler.general.IncludePaths>
-  <avrgcc.assembler.debugging.DebugLevel>Default (-Wa,-g)</avrgcc.assembler.debugging.DebugLevel>
-</AvrGcc>
+        <avrgcc.common.Device>-mmcu=atxmega256a3u -B "%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\gcc\dev\atxmega256a3u"</avrgcc.common.Device>
+        <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
+        <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
+        <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
+        <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
+        <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
+        <avrgcc.compiler.symbols.DefSymbols>
+          <ListValues>
+            <Value>DEBUG</Value>
+            <Value>BOARD=USER_BOARD</Value>
+            <Value>IOPORT_XMEGA_COMPAT</Value>
+            <Value>TEST_SUITE_DEFINE_ASSERT_MACRO</Value>
+            <Value>_ASSERT_ENABLE_</Value>
+          </ListValues>
+        </avrgcc.compiler.symbols.DefSymbols>
+        <avrgcc.compiler.directories.IncludePaths>
+          <ListValues>
+            <Value>../src/ASF/common/boards/user_board</Value>
+            <Value>../src/ASF/common/boards</Value>
+            <Value>../src/ASF/xmega/utils/preprocessor</Value>
+            <Value>../src/ASF/xmega/utils</Value>
+            <Value>../src/ASF/common/utils</Value>
+            <Value>../src</Value>
+            <Value>../src/config</Value>
+            <Value>../src/framework</Value>
+            <Value>../src/utils</Value>
+            <Value>../src/tasks</Value>
+            <Value>../src/drivers</Value>
+            <Value>../src/ASF/xmega/drivers/cpu</Value>
+            <Value>../src/ASF/xmega/drivers/nvm</Value>
+            <Value>../src/ASF/xmega/drivers/pmic</Value>
+            <Value>../src/ASF/xmega/drivers/sleep</Value>
+            <Value>../src/ASF/xmega/drivers/spi</Value>
+            <Value>../src/ASF/xmega/drivers/tc</Value>
+            <Value>../src/ASF/common/services/clock</Value>
+            <Value>../src/ASF/common/services/gpio</Value>
+            <Value>../src/ASF/common/services/ioport</Value>
+            <Value>../src/ASF/common/services/sleepmgr</Value>
+            <Value>../src/ASF/xmega/drivers/twi</Value>
+            <Value>../src/ASF/xmega/drivers/usart</Value>
+            <Value>../src/ASF/common/services/hugemem</Value>
+            <Value>../src/ASF/xmega/drivers/dma</Value>
+            <Value>../src/ASF/common/services/usb</Value>
+            <Value>../src/ASF/common/services/usb/class/cdc</Value>
+            <Value>../src/ASF/common/services/usb/class/cdc/device</Value>
+            <Value>../src/ASF/common/services/usb/udc</Value>
+            <Value>../src/ASF/xmega/drivers/usb</Value>
+            <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
+          </ListValues>
+        </avrgcc.compiler.directories.IncludePaths>
+        <avrgcc.compiler.optimization.level>Optimize debugging experience (-Og)</avrgcc.compiler.optimization.level>
+        <avrgcc.compiler.optimization.OtherFlags>-fdata-sections</avrgcc.compiler.optimization.OtherFlags>
+        <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
+        <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
+        <avrgcc.compiler.optimization.DebugLevel>Maximum (-g3)</avrgcc.compiler.optimization.DebugLevel>
+        <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
+        <avrgcc.compiler.miscellaneous.OtherFlags>-std=gnu99 -fno-strict-aliasing -Wstrict-prototypes -Wmissing-prototypes -Werror-implicit-function-declaration -Wpointer-arith -mrelax</avrgcc.compiler.miscellaneous.OtherFlags>
+        <avrgcc.linker.libraries.Libraries>
+          <ListValues>
+            <Value>libm</Value>
+          </ListValues>
+        </avrgcc.linker.libraries.Libraries>
+        <avrgcc.linker.miscellaneous.LinkerFlags>-Wl,--relax</avrgcc.linker.miscellaneous.LinkerFlags>
+        <avrgcc.assembler.general.AssemblerFlags>-mrelax -DBOARD=USER_BOARD</avrgcc.assembler.general.AssemblerFlags>
+        <avrgcc.assembler.general.IncludePaths>
+          <ListValues>
+            <Value>../src/ASF/common/boards/user_board</Value>
+            <Value>../src/ASF/common/boards</Value>
+            <Value>../src/ASF/xmega/utils/preprocessor</Value>
+            <Value>../src/ASF/xmega/utils</Value>
+            <Value>../src/ASF/common/utils</Value>
+            <Value>../src</Value>
+            <Value>../src/config</Value>
+            <Value>../src/ASF/xmega/drivers/cpu</Value>
+            <Value>../src/ASF/xmega/drivers/nvm</Value>
+            <Value>../src/ASF/xmega/drivers/pmic</Value>
+            <Value>../src/ASF/xmega/drivers/sleep</Value>
+            <Value>../src/ASF/xmega/drivers/spi</Value>
+            <Value>../src/ASF/xmega/drivers/tc</Value>
+            <Value>../src/ASF/common/services/clock</Value>
+            <Value>../src/ASF/common/services/gpio</Value>
+            <Value>../src/ASF/common/services/ioport</Value>
+            <Value>../src/ASF/common/services/sleepmgr</Value>
+            <Value>../src/ASF/xmega/drivers/twi</Value>
+            <Value>../src/ASF/xmega/drivers/usart</Value>
+            <Value>../src/ASF/common/services/hugemem</Value>
+            <Value>../src/ASF/xmega/drivers/dma</Value>
+            <Value>../src/ASF/common/services/usb</Value>
+            <Value>../src/ASF/common/services/usb/class/cdc</Value>
+            <Value>../src/ASF/common/services/usb/class/cdc/device</Value>
+            <Value>../src/ASF/common/services/usb/udc</Value>
+            <Value>../src/ASF/xmega/drivers/usb</Value>
+            <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
+          </ListValues>
+        </avrgcc.assembler.general.IncludePaths>
+        <avrgcc.assembler.debugging.DebugLevel>Default (-Wa,-g)</avrgcc.assembler.debugging.DebugLevel>
+      </AvrGcc>
     </ToolchainSettings>
   </PropertyGroup>
   <ItemGroup>

--- a/karman-avionics/karman-avionics.cproj
+++ b/karman-avionics/karman-avionics.cproj
@@ -137,10 +137,9 @@
         <board id="board.user_board.xmegaau" value="Add" config="" content-id="Atmel.ASF" />
       </framework-data>
     </AsfFrameworkConfig>
-    <avrtool>
-    </avrtool>
-    <avrtoolserialnumber />
-    <avrdeviceexpectedsignature>0x1E9742</avrdeviceexpectedsignature>
+    <avrtool>com.atmel.avrdbg.tool.atmelice</avrtool>
+    <avrtoolserialnumber>J41800022744</avrtoolserialnumber>
+    <avrdeviceexpectedsignature>0x1E9842</avrdeviceexpectedsignature>
     <com_atmel_avrdbg_tool_simulator>
       <ToolOptions>
         <InterfaceProperties>
@@ -153,7 +152,7 @@
       </ToolNumber>
       <ToolName>Simulator</ToolName>
     </com_atmel_avrdbg_tool_simulator>
-    <avrtoolinterface />
+    <avrtoolinterface>PDI</avrtoolinterface>
     <custom>
       <ToolOptions xmlns="">
         <InterfaceProperties>
@@ -166,101 +165,113 @@
       </ToolNumber>
       <ToolName xmlns="">Custom Programming Tool</ToolName>
     </custom>
+    <com_atmel_avrdbg_tool_atmelice>
+      <ToolOptions>
+        <InterfaceProperties>
+          <PdiClock>4000000</PdiClock>
+        </InterfaceProperties>
+        <InterfaceName>PDI</InterfaceName>
+      </ToolOptions>
+      <ToolType>com.atmel.avrdbg.tool.atmelice</ToolType>
+      <ToolNumber>J41800022744</ToolNumber>
+      <ToolName>Atmel-ICE</ToolName>
+    </com_atmel_avrdbg_tool_atmelice>
+    <avrtoolinterfaceclock>4000000</avrtoolinterfaceclock>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <ToolchainSettings>
       <AvrGcc>
-  <avrgcc.common.Device>-mmcu=atxmega256a3u -B "%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\gcc\dev\atxmega256a3u"</avrgcc.common.Device>
-  <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
-  <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
-  <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
-  <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
-  <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
-  <avrgcc.compiler.symbols.DefSymbols>
-    <ListValues>
-      <Value>NDEBUG</Value>
-      <Value>BOARD=USER_BOARD</Value>
-      <Value>IOPORT_XMEGA_COMPAT</Value>
-      <Value>TEST_SUITE_DEFINE_ASSERT_MACRO</Value>
-      <Value>_ASSERT_ENABLE_</Value>
-    </ListValues>
-  </avrgcc.compiler.symbols.DefSymbols>
-  <avrgcc.compiler.directories.IncludePaths>
-    <ListValues>
-      <Value>../src/ASF/common/boards/user_board</Value>
-      <Value>../src/ASF/common/boards</Value>
-      <Value>../src/ASF/xmega/utils/preprocessor</Value>
-      <Value>../src/ASF/xmega/utils</Value>
-      <Value>../src/ASF/common/utils</Value>
-      <Value>../src</Value>
-      <Value>../src/config</Value>
-      <Value>../src/ASF/xmega/drivers/cpu</Value>
-      <Value>../src/ASF/xmega/drivers/nvm</Value>
-      <Value>../src/ASF/xmega/drivers/pmic</Value>
-      <Value>../src/ASF/xmega/drivers/sleep</Value>
-      <Value>../src/ASF/xmega/drivers/spi</Value>
-      <Value>../src/ASF/xmega/drivers/tc</Value>
-      <Value>../src/ASF/common/services/clock</Value>
-      <Value>../src/ASF/common/services/gpio</Value>
-      <Value>../src/ASF/common/services/ioport</Value>
-      <Value>../src/ASF/common/services/sleepmgr</Value>
-      <Value>../src/ASF/xmega/drivers/twi</Value>
-      <Value>../src/ASF/xmega/drivers/usart</Value>
-      <Value>../src/ASF/common/services/hugemem</Value>
-      <Value>../src/ASF/xmega/drivers/dma</Value>
-      <Value>../src/ASF/common/services/usb</Value>
-      <Value>../src/ASF/common/services/usb/class/cdc</Value>
-      <Value>../src/ASF/common/services/usb/class/cdc/device</Value>
-      <Value>../src/ASF/common/services/usb/udc</Value>
-      <Value>../src/ASF/xmega/drivers/usb</Value>
-      <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
-    </ListValues>
-  </avrgcc.compiler.directories.IncludePaths>
-  <avrgcc.compiler.optimization.level>Optimize for size (-Os)</avrgcc.compiler.optimization.level>
-  <avrgcc.compiler.optimization.OtherFlags>-fdata-sections</avrgcc.compiler.optimization.OtherFlags>
-  <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
-  <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
-  <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
-  <avrgcc.compiler.miscellaneous.OtherFlags>-std=gnu99 -fno-strict-aliasing -Wstrict-prototypes -Wmissing-prototypes -Werror-implicit-function-declaration -Wpointer-arith -mrelax</avrgcc.compiler.miscellaneous.OtherFlags>
-  <avrgcc.linker.libraries.Libraries>
-    <ListValues>
-      <Value>libm</Value>
-    </ListValues>
-  </avrgcc.linker.libraries.Libraries>
-  <avrgcc.linker.miscellaneous.LinkerFlags>-Wl,--relax</avrgcc.linker.miscellaneous.LinkerFlags>
-  <avrgcc.assembler.general.AssemblerFlags>-mrelax -DBOARD=USER_BOARD</avrgcc.assembler.general.AssemblerFlags>
-  <avrgcc.assembler.general.IncludePaths>
-    <ListValues>
-      <Value>../src/ASF/common/boards/user_board</Value>
-      <Value>../src/ASF/common/boards</Value>
-      <Value>../src/ASF/xmega/utils/preprocessor</Value>
-      <Value>../src/ASF/xmega/utils</Value>
-      <Value>../src/ASF/common/utils</Value>
-      <Value>../src</Value>
-      <Value>../src/config</Value>
-      <Value>../src/ASF/xmega/drivers/cpu</Value>
-      <Value>../src/ASF/xmega/drivers/nvm</Value>
-      <Value>../src/ASF/xmega/drivers/pmic</Value>
-      <Value>../src/ASF/xmega/drivers/sleep</Value>
-      <Value>../src/ASF/xmega/drivers/spi</Value>
-      <Value>../src/ASF/xmega/drivers/tc</Value>
-      <Value>../src/ASF/common/services/clock</Value>
-      <Value>../src/ASF/common/services/gpio</Value>
-      <Value>../src/ASF/common/services/ioport</Value>
-      <Value>../src/ASF/common/services/sleepmgr</Value>
-      <Value>../src/ASF/xmega/drivers/twi</Value>
-      <Value>../src/ASF/xmega/drivers/usart</Value>
-      <Value>../src/ASF/common/services/hugemem</Value>
-      <Value>../src/ASF/xmega/drivers/dma</Value>
-      <Value>../src/ASF/common/services/usb</Value>
-      <Value>../src/ASF/common/services/usb/class/cdc</Value>
-      <Value>../src/ASF/common/services/usb/class/cdc/device</Value>
-      <Value>../src/ASF/common/services/usb/udc</Value>
-      <Value>../src/ASF/xmega/drivers/usb</Value>
-      <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
-    </ListValues>
-  </avrgcc.assembler.general.IncludePaths>
-</AvrGcc>
+        <avrgcc.common.Device>-mmcu=atxmega256a3u -B "%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\gcc\dev\atxmega256a3u"</avrgcc.common.Device>
+        <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
+        <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
+        <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
+        <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
+        <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
+        <avrgcc.compiler.symbols.DefSymbols>
+          <ListValues>
+            <Value>NDEBUG</Value>
+            <Value>BOARD=USER_BOARD</Value>
+            <Value>IOPORT_XMEGA_COMPAT</Value>
+            <Value>TEST_SUITE_DEFINE_ASSERT_MACRO</Value>
+            <Value>_ASSERT_ENABLE_</Value>
+          </ListValues>
+        </avrgcc.compiler.symbols.DefSymbols>
+        <avrgcc.compiler.directories.IncludePaths>
+          <ListValues>
+            <Value>../src/ASF/common/boards/user_board</Value>
+            <Value>../src/ASF/common/boards</Value>
+            <Value>../src/ASF/xmega/utils/preprocessor</Value>
+            <Value>../src/ASF/xmega/utils</Value>
+            <Value>../src/ASF/common/utils</Value>
+            <Value>../src</Value>
+            <Value>../src/config</Value>
+            <Value>../src/ASF/xmega/drivers/cpu</Value>
+            <Value>../src/ASF/xmega/drivers/nvm</Value>
+            <Value>../src/ASF/xmega/drivers/pmic</Value>
+            <Value>../src/ASF/xmega/drivers/sleep</Value>
+            <Value>../src/ASF/xmega/drivers/spi</Value>
+            <Value>../src/ASF/xmega/drivers/tc</Value>
+            <Value>../src/ASF/common/services/clock</Value>
+            <Value>../src/ASF/common/services/gpio</Value>
+            <Value>../src/ASF/common/services/ioport</Value>
+            <Value>../src/ASF/common/services/sleepmgr</Value>
+            <Value>../src/ASF/xmega/drivers/twi</Value>
+            <Value>../src/ASF/xmega/drivers/usart</Value>
+            <Value>../src/ASF/common/services/hugemem</Value>
+            <Value>../src/ASF/xmega/drivers/dma</Value>
+            <Value>../src/ASF/common/services/usb</Value>
+            <Value>../src/ASF/common/services/usb/class/cdc</Value>
+            <Value>../src/ASF/common/services/usb/class/cdc/device</Value>
+            <Value>../src/ASF/common/services/usb/udc</Value>
+            <Value>../src/ASF/xmega/drivers/usb</Value>
+            <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
+          </ListValues>
+        </avrgcc.compiler.directories.IncludePaths>
+        <avrgcc.compiler.optimization.level>Optimize for size (-Os)</avrgcc.compiler.optimization.level>
+        <avrgcc.compiler.optimization.OtherFlags>-fdata-sections</avrgcc.compiler.optimization.OtherFlags>
+        <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
+        <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
+        <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
+        <avrgcc.compiler.miscellaneous.OtherFlags>-std=gnu99 -fno-strict-aliasing -Wstrict-prototypes -Wmissing-prototypes -Werror-implicit-function-declaration -Wpointer-arith -mrelax</avrgcc.compiler.miscellaneous.OtherFlags>
+        <avrgcc.linker.libraries.Libraries>
+          <ListValues>
+            <Value>libm</Value>
+          </ListValues>
+        </avrgcc.linker.libraries.Libraries>
+        <avrgcc.linker.miscellaneous.LinkerFlags>-Wl,--relax</avrgcc.linker.miscellaneous.LinkerFlags>
+        <avrgcc.assembler.general.AssemblerFlags>-mrelax -DBOARD=USER_BOARD</avrgcc.assembler.general.AssemblerFlags>
+        <avrgcc.assembler.general.IncludePaths>
+          <ListValues>
+            <Value>../src/ASF/common/boards/user_board</Value>
+            <Value>../src/ASF/common/boards</Value>
+            <Value>../src/ASF/xmega/utils/preprocessor</Value>
+            <Value>../src/ASF/xmega/utils</Value>
+            <Value>../src/ASF/common/utils</Value>
+            <Value>../src</Value>
+            <Value>../src/config</Value>
+            <Value>../src/ASF/xmega/drivers/cpu</Value>
+            <Value>../src/ASF/xmega/drivers/nvm</Value>
+            <Value>../src/ASF/xmega/drivers/pmic</Value>
+            <Value>../src/ASF/xmega/drivers/sleep</Value>
+            <Value>../src/ASF/xmega/drivers/spi</Value>
+            <Value>../src/ASF/xmega/drivers/tc</Value>
+            <Value>../src/ASF/common/services/clock</Value>
+            <Value>../src/ASF/common/services/gpio</Value>
+            <Value>../src/ASF/common/services/ioport</Value>
+            <Value>../src/ASF/common/services/sleepmgr</Value>
+            <Value>../src/ASF/xmega/drivers/twi</Value>
+            <Value>../src/ASF/xmega/drivers/usart</Value>
+            <Value>../src/ASF/common/services/hugemem</Value>
+            <Value>../src/ASF/xmega/drivers/dma</Value>
+            <Value>../src/ASF/common/services/usb</Value>
+            <Value>../src/ASF/common/services/usb/class/cdc</Value>
+            <Value>../src/ASF/common/services/usb/class/cdc/device</Value>
+            <Value>../src/ASF/common/services/usb/udc</Value>
+            <Value>../src/ASF/xmega/drivers/usb</Value>
+            <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
+          </ListValues>
+        </avrgcc.assembler.general.IncludePaths>
+      </AvrGcc>
     </ToolchainSettings>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -316,7 +327,7 @@
       <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
     </ListValues>
   </avrgcc.compiler.directories.IncludePaths>
-  <avrgcc.compiler.optimization.level>Optimize (-O1)</avrgcc.compiler.optimization.level>
+  <avrgcc.compiler.optimization.level>Optimize debugging experience (-Og)</avrgcc.compiler.optimization.level>
   <avrgcc.compiler.optimization.OtherFlags>-fdata-sections</avrgcc.compiler.optimization.OtherFlags>
   <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
   <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>

--- a/karman-avionics/src/ASF/common/boards/user_board/init.c
+++ b/karman-avionics/src/ASF/common/boards/user_board/init.c
@@ -97,11 +97,11 @@ void board_init(void)
     init_sensor_task();
 
     /* Initializes SPI for radio module, sets up cs pin for it */
-    init_radio_task();
+    //init_radio_task();
 
     /* Initializes SPI for External Flash Memory, sets up CS pin for it */
-    init_flashmem();
+    //init_flashmem();
 
     /* Initializes the USB CDC interface */
-    init_usb();
+    //init_usb();
 }

--- a/karman-avionics/src/ASF/common/boards/user_board/init.c
+++ b/karman-avionics/src/ASF/common/boards/user_board/init.c
@@ -100,7 +100,7 @@ void board_init(void)
     //init_radio_task();
 
     /* Initializes SPI for External Flash Memory, sets up CS pin for it */
-    //init_flashmem();
+    init_flashmem();
 
     /* Initializes the USB CDC interface */
     //init_usb();

--- a/karman-avionics/src/drivers/ms5607-02ba03.c
+++ b/karman-avionics/src/drivers/ms5607-02ba03.c
@@ -77,14 +77,13 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
 
     /** Send BLOCKING request as this is done during initialization */
     /** Tell SPI to NOT pull CS high after transaction to allow for reset time. */
-    spi_master_blocking_send_request(gAltimeterControl.spi_master,
+    spi_master_blocking_send_req_cslow(gAltimeterControl.spi_master,
                        &(gAltimeterControl.cs_info),
                        gAltimeterControl.spi_send_buffer,
                        1,
                        gAltimeterControl.spi_recv_buffer,
                        0,
-                       &(gAltimeterControl.send_complete),
-                       true);
+                       &(gAltimeterControl.send_complete));
  }
 
  /** 
@@ -111,8 +110,8 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
                                         1,
                                         gAltimeterControl.spi_recv_buffer,
                                         3,
-                                        &(gAltimeterControl.send_complete),
-                                        false);
+                                        &(gAltimeterControl.send_complete));
+
         *calptr = ((uint16_t)gAltimeterControl.spi_recv_buffer[1] << 8) | gAltimeterControl.spi_recv_buffer[0];
         calptr++;
     }
@@ -130,12 +129,12 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
     gAltimeterControl.spi_send_buffer[0] = ALTIMETER_CONVERT_D1;
 
     spi_master_enqueue(gAltimeterControl.spi_master,
-    &gAltimeterControl.cs_info,
-    gAltimeterControl.spi_send_buffer,
-    1,
-    gAltimeterControl.spi_recv_buffer,
-    0,
-    &gAltimeterControl.send_complete);
+                       &(gAltimeterControl.cs_info),
+                       gAltimeterControl.spi_send_buffer,
+                       1,
+                       gAltimeterControl.spi_recv_buffer,
+                       0,
+                       &(gAltimeterControl.send_complete));
  }
 
 /** 
@@ -152,12 +151,12 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
      gAltimeterControl.spi_send_buffer[0] = ALTIMETER_CONVERT_D2;
 
      spi_master_enqueue(gAltimeterControl.spi_master,
-     &gAltimeterControl.cs_info,
-     gAltimeterControl.spi_send_buffer,
-     1,
-     gAltimeterControl.spi_recv_buffer,
-     0,
-     &gAltimeterControl.send_complete);
+                        &(gAltimeterControl.cs_info),
+                        gAltimeterControl.spi_send_buffer,
+                        1,
+                        gAltimeterControl.spi_recv_buffer,
+                        0,
+                        &(gAltimeterControl.send_complete));
  }
 
  /** 
@@ -168,20 +167,20 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
   *
   * 24 bits for pressure/temperature. NOTE: Always convert d1 and d2 first 
   */
- void ms5607_02ba03_read_data(void)
- {
-        memset((void *)gAltimeterControl.spi_send_buffer, 0, sizeof(gAltimeterControl.spi_send_buffer));
+void ms5607_02ba03_read_data(void)
+{
+    memset((void *)gAltimeterControl.spi_send_buffer, 0, sizeof(gAltimeterControl.spi_send_buffer));
         
-        gAltimeterControl.spi_send_buffer[0] = ALTIMETER_ADC_READ;
+    gAltimeterControl.spi_send_buffer[0] = ALTIMETER_ADC_READ;
 
-        spi_master_enqueue(gAltimeterControl.spi_master,
-        &gAltimeterControl.cs_info,
-        gAltimeterControl.spi_send_buffer,
-        1,
-        gAltimeterControl.spi_recv_buffer,
-        4,
-        &gAltimeterControl.send_complete);
- }
+    spi_master_enqueue(gAltimeterControl.spi_master,
+                       &(gAltimeterControl.cs_info),
+                       gAltimeterControl.spi_send_buffer,
+                       1,
+                       gAltimeterControl.spi_recv_buffer,
+                       4,
+                       &(gAltimeterControl.send_complete));
+}
 
 /** 
  * @brief Helper function to re-order bytes to use as a 32 bit value.

--- a/karman-avionics/src/drivers/ms5607-02ba03.c
+++ b/karman-avionics/src/drivers/ms5607-02ba03.c
@@ -28,21 +28,21 @@
  #define ALTIMETER_CONVERT_D2_1024  (0x54) /**< D2 Conversion command with 10 bits of data */
  #define ALTIMETER_CONVERT_D2_2048  (0x56) /**< D2 Conversion command with 11 bits of data */
  #define ALTIMETER_CONVERT_D2_4096  (0x58) /**< D2 Conversion command with 12 bits of data */
- #define ALTIMETER_CONVERT_D1       (ALTIMETER_CONVERT_D1_4096) /**< Use most ADC bits */
- #define ALTIMETER_CONVERT_D2       (ALTIMETER_CONVERT_D2_4096) /**< Use most ADC bits */
+ #define ALTIMETER_CONVERT_D1       (ALTIMETER_CONVERT_D1_2048) /**< Use most ADC bits */
+ #define ALTIMETER_CONVERT_D2       (ALTIMETER_CONVERT_D2_2048) /**< Use most ADC bits */
  #define ALTIMETER_PROM_BASE        (0xA0) /**< PROM addresses are 0xA0 to 0xAE */
  #define ALTIMETER_ADC_READ         (0x00) /**< ADC Read command */
- #define ALTIMETER_NUM_CAL          (6)    /**< There are six calibraiton values */
+ #define ALTIMETER_NUM_CAL          (6)    /**< There are six calibration values */
 
  /** File scope global variable with control data for the altimeter */
  ms5607_02ba03_control_t gAltimeterControl;
 
 /** 
-* @brief Intialize the Altimeter.
+* @brief Initialize the Altimeter.
 *
 * spi_master is a reference to the SPI controller for the sensor SPI Bus.
 * This is the initializer for the altimeter driver. 
-* It initializes buffers for SPI and other control data. Hardware initalization is done in init.c
+* It initializes buffers for SPI and other control data. Hardware initialization is done in init.c
 * Also resets the altimeter and retrieves the configuration data.
 */
 void ms5607_02ba03_init(spi_master_t *spi_master)
@@ -59,7 +59,7 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
 
     /** Call initial functions to prepare altimeter. */
     ms5607_02ba03_reset();
-    timer_delay_us(2800); /** Delay 2.8 ms to allow for reset */
+    timer_delay_ms(3); /** Delay 3 ms to allow for reset */
     gAltimeterControl.cs_info.csPort->OUTSET = gAltimeterControl.cs_info.pinBitMask; /** Pull CS High to allow continued operation */
     ms5607_02ba03_read_prom();
 }
@@ -95,36 +95,27 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
   */
  void ms5607_02ba03_read_prom(void)
  {
+    uint8_t i;
+    uint16_t *calptr = (uint16_t *)&(gAltimeterControl.calibration_vals);
     /** Grab addresses 1 through 6 of PROM (datasheet page 11) */
     /** Each one is 16 bits. */
     memset((void *)gAltimeterControl.spi_send_buffer, 0, sizeof(gAltimeterControl.spi_send_buffer));
-    gAltimeterControl.spi_send_buffer[0] = ALTIMETER_PROM_BASE + 0x2; /* 1st cal value*/
-    gAltimeterControl.spi_send_buffer[3] = ALTIMETER_PROM_BASE + 0x4;
-    gAltimeterControl.spi_send_buffer[6] = ALTIMETER_PROM_BASE + 0x6;
-    gAltimeterControl.spi_send_buffer[9] = ALTIMETER_PROM_BASE + 0x8;
-    gAltimeterControl.spi_send_buffer[12] = ALTIMETER_PROM_BASE + 0xA;
-    gAltimeterControl.spi_send_buffer[15] = ALTIMETER_PROM_BASE + 0xC;
 
-    /** Send BLOCKING request as this is done during initialization */
-    spi_master_blocking_send_request(gAltimeterControl.spi_master,
-                                    &(gAltimeterControl.cs_info),
-                                    gAltimeterControl.spi_send_buffer,
-                                    3 * ALTIMETER_NUM_CAL,
-                                    gAltimeterControl.spi_recv_buffer,
-                                    3 * ALTIMETER_NUM_CAL,
-                                    &(gAltimeterControl.send_complete),
-                                    false);
-
-	/** The above code puts the prom into read only mode. When it is done the spi_recv_buffer
-	 * Should be written to allowing us to assign specific variables to the parts of that data*/
-
-    /** Retrieve the calibration values from the spi receive buffer. */
-    gAltimeterControl.calibration_vals.sens = *(uint16_t *)(&(gAltimeterControl.spi_recv_buffer[1]));
-    gAltimeterControl.calibration_vals.offset = *(uint16_t *)(&(gAltimeterControl.spi_recv_buffer[4]));
-    gAltimeterControl.calibration_vals.tcs = *(uint16_t *)(&(gAltimeterControl.spi_recv_buffer[7]));
-    gAltimeterControl.calibration_vals.tco = *(uint16_t *)(&(gAltimeterControl.spi_recv_buffer[10]));
-    gAltimeterControl.calibration_vals.t_ref = *(uint16_t *)(&(gAltimeterControl.spi_recv_buffer[13]));
-    gAltimeterControl.calibration_vals.temp_sens = *(uint16_t *)(&(gAltimeterControl.spi_recv_buffer[16]));
+    for(i = ALTIMETER_PROM_BASE + 2; i < ALTIMETER_PROM_BASE + 0x0E; i = i+2)
+    {
+        gAltimeterControl.spi_send_buffer[0] = i;
+        /** Send BLOCKING request as this is done during initialization */
+        spi_master_blocking_send_request(gAltimeterControl.spi_master,
+                                        &(gAltimeterControl.cs_info),
+                                        gAltimeterControl.spi_send_buffer,
+                                        1,
+                                        gAltimeterControl.spi_recv_buffer,
+                                        3,
+                                        &(gAltimeterControl.send_complete),
+                                        false);
+        *calptr = ((uint16_t)gAltimeterControl.spi_recv_buffer[1] << 8) | gAltimeterControl.spi_recv_buffer[0];
+        calptr++;
+    }
  }
 
  /** 
@@ -145,7 +136,7 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
     gAltimeterControl.spi_recv_buffer,
     0,
     &gAltimeterControl.send_complete,
-    true);
+    false);
  }
 
 /** 
@@ -168,7 +159,7 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
      gAltimeterControl.spi_recv_buffer,
      0,
      &gAltimeterControl.send_complete,
-     true);
+     false);
  }
 
  /** 
@@ -248,7 +239,6 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
             /* if 8ms done */
             if(get_timer_count() - gAltimeterControl.time_start > EIGHT_MS)
             {
-                gAltimeterControl.cs_info.csPort->OUTSET = gAltimeterControl.cs_info.pinBitMask; /** Pull CS High to allow continued operation */
                 ms5607_02ba03_read_data();
                 gAltimeterControl.get_data_state = WAIT_D1_READ;
                 returnStatus = SENSOR_WAITING;
@@ -278,7 +268,6 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
             /* if 8ms done */
             if(get_timer_count() - gAltimeterControl.time_start > EIGHT_MS)
             {
-                gAltimeterControl.cs_info.csPort->OUTSET = gAltimeterControl.cs_info.pinBitMask; /** Pull CS High to allow continued operation */
                 ms5607_02ba03_read_data();
                 gAltimeterControl.get_data_state = WAIT_D2_READ;
                 returnStatus = SENSOR_WAITING;

--- a/karman-avionics/src/drivers/ms5607-02ba03.c
+++ b/karman-avionics/src/drivers/ms5607-02ba03.c
@@ -135,8 +135,7 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
     1,
     gAltimeterControl.spi_recv_buffer,
     0,
-    &gAltimeterControl.send_complete,
-    false);
+    &gAltimeterControl.send_complete);
  }
 
 /** 
@@ -158,8 +157,7 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
      1,
      gAltimeterControl.spi_recv_buffer,
      0,
-     &gAltimeterControl.send_complete,
-     false);
+     &gAltimeterControl.send_complete);
  }
 
  /** 
@@ -182,8 +180,7 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
         1,
         gAltimeterControl.spi_recv_buffer,
         4,
-        &gAltimeterControl.send_complete,
-        false);
+        &gAltimeterControl.send_complete);
  }
 
 /** 

--- a/karman-avionics/src/drivers/ms5607-02ba03.c
+++ b/karman-avionics/src/drivers/ms5607-02ba03.c
@@ -59,7 +59,7 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
 
     /** Call initial functions to prepare altimeter. */
     ms5607_02ba03_reset();
-    timer_delay_ms(3); /** Delay 3 ms to allow for reset */
+    timer_delay_us(2800); /** Delay 2.8 ms to allow for reset */
     gAltimeterControl.cs_info.csPort->OUTSET = gAltimeterControl.cs_info.pinBitMask; /** Pull CS High to allow continued operation */
     ms5607_02ba03_read_prom();
 }
@@ -145,7 +145,7 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
     gAltimeterControl.spi_recv_buffer,
     0,
     &gAltimeterControl.send_complete,
-    false);
+    true);
  }
 
 /** 
@@ -168,7 +168,7 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
      gAltimeterControl.spi_recv_buffer,
      0,
      &gAltimeterControl.send_complete,
-     false);
+     true);
  }
 
  /** 
@@ -246,8 +246,9 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
         case WAIT_8ms_D1:
             /* wait 8ms */
             /* if 8ms done */
-            if(get_timer_count() - gAltimeterControl.time_start >= EIGHT_MS)
+            if(get_timer_count() - gAltimeterControl.time_start > EIGHT_MS)
             {
+                gAltimeterControl.cs_info.csPort->OUTSET = gAltimeterControl.cs_info.pinBitMask; /** Pull CS High to allow continued operation */
                 ms5607_02ba03_read_data();
                 gAltimeterControl.get_data_state = WAIT_D1_READ;
                 returnStatus = SENSOR_WAITING;
@@ -275,8 +276,9 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
         case WAIT_8ms_D2:
             /* wait 8ms */
             /* if 8ms done */
-            if(get_timer_count() - gAltimeterControl.time_start >= EIGHT_MS)
+            if(get_timer_count() - gAltimeterControl.time_start > EIGHT_MS)
             {
+                gAltimeterControl.cs_info.csPort->OUTSET = gAltimeterControl.cs_info.pinBitMask; /** Pull CS High to allow continued operation */
                 ms5607_02ba03_read_data();
                 gAltimeterControl.get_data_state = WAIT_D2_READ;
                 returnStatus = SENSOR_WAITING;

--- a/karman-avionics/src/drivers/ms5607-02ba03.c
+++ b/karman-avionics/src/drivers/ms5607-02ba03.c
@@ -60,6 +60,7 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
     /** Call initial functions to prepare altimeter. */
     ms5607_02ba03_reset();
     timer_delay_ms(3); /** Delay 3 ms to allow for reset */
+    gAltimeterControl.cs_info.csPort->OUTSET = gAltimeterControl.cs_info.pinBitMask; /** Pull CS High to allow continued operation */
     ms5607_02ba03_read_prom();
 }
 
@@ -75,13 +76,15 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
     gAltimeterControl.spi_send_buffer[0] = ALTIMETER_RESET;
 
     /** Send BLOCKING request as this is done during initialization */
+    /** Tell SPI to NOT pull CS high after transaction to allow for reset time. */
     spi_master_blocking_send_request(gAltimeterControl.spi_master,
                        &(gAltimeterControl.cs_info),
                        gAltimeterControl.spi_send_buffer,
                        1,
                        gAltimeterControl.spi_recv_buffer,
                        0,
-                       &(gAltimeterControl.send_complete));
+                       &(gAltimeterControl.send_complete),
+                       true);
  }
 
  /** 
@@ -109,7 +112,8 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
                                     3 * ALTIMETER_NUM_CAL,
                                     gAltimeterControl.spi_recv_buffer,
                                     3 * ALTIMETER_NUM_CAL,
-                                    &(gAltimeterControl.send_complete));
+                                    &(gAltimeterControl.send_complete),
+                                    false);
 
 	/** The above code puts the prom into read only mode. When it is done the spi_recv_buffer
 	 * Should be written to allowing us to assign specific variables to the parts of that data*/
@@ -140,7 +144,8 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
     1,
     gAltimeterControl.spi_recv_buffer,
     0,
-    &gAltimeterControl.send_complete);
+    &gAltimeterControl.send_complete,
+    false);
  }
 
 /** 
@@ -162,7 +167,8 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
      1,
      gAltimeterControl.spi_recv_buffer,
      0,
-     &gAltimeterControl.send_complete);
+     &gAltimeterControl.send_complete,
+     false);
  }
 
  /** 
@@ -185,7 +191,8 @@ void ms5607_02ba03_init(spi_master_t *spi_master)
         1,
         gAltimeterControl.spi_recv_buffer,
         4,
-        &gAltimeterControl.send_complete);
+        &gAltimeterControl.send_complete,
+        false);
  }
 
 /** 

--- a/karman-avionics/src/drivers/ms5607-02ba03.h
+++ b/karman-avionics/src/drivers/ms5607-02ba03.h
@@ -41,8 +41,8 @@ typedef struct altimeter_raw_s
 /** Final computed data */
 typedef struct altimeter_data_s
 {
-    int32_t temp;           /**< Temperature */
-    int32_t pressure;       /**< Pressure */
+    int32_t temp;           /**< Temperature in the form YY.XX deg c */
+    int32_t pressure;       /**< Pressure in the form YYYYYY.XX millibar (bizzare right?) */
 } ms5607_02ba03_data_t;
 
 /** State machine for altimeter */

--- a/karman-avionics/src/drivers/n25q_512.c
+++ b/karman-avionics/src/drivers/n25q_512.c
@@ -111,8 +111,7 @@ void extflash_initialize_regs(void)
                                            1,
                                            (void *)(gExtflashControl.spi_recv_buffer),
                                            0,
-                                           &(gExtflashControl.send_complete),
-                                           false);
+                                           &(gExtflashControl.send_complete));
 }
 
 /** 
@@ -159,8 +158,7 @@ Bool extflash_read(uint32_t addr, size_t num_bytes, uint8_t *buf, Bool block)
                                                       EXTFLASH_CMDADDR_SIZE,
                                                       (void *)(gExtflashControl.spi_recv_buffer),
                                                       EXTFLASH_CMDADDR_SIZE + num_bytes,
-                                                      &(gExtflashControl.send_complete),
-                                                      false);
+                                                      &(gExtflashControl.send_complete));
             /* Copy data into caller's buffer, ignoring garbage data from sending command */
             memcpy((void *)buf, (void *)(&(gExtflashControl.spi_recv_buffer[5])), num_bytes);
         }
@@ -245,8 +243,7 @@ Bool extflash_read_status_reg(uint16_t *buf, Bool block)
                                                   1,
                                                   (void *)buf,
                                                   2,
-                                                  &(gExtflashControl.send_complete),
-                                                  false);
+                                                  &(gExtflashControl.send_complete));
     }
     else
     {
@@ -282,8 +279,7 @@ Bool extflash_write_enable(Bool block)
                                                    1,
                                                    (void *)(gExtflashControl.spi_recv_buffer),
                                                    0,
-                                                   &(gExtflashControl.send_complete),
-                                                   false);
+                                                   &(gExtflashControl.send_complete));
 
         /* Keep reading the status regsiter until the write enable is confirmed. No timeout. this is pretty dangerous tbh. */
         do 
@@ -334,8 +330,7 @@ Bool extflash_write_one(uint16_t num_bytes, uint32_t addr, uint8_t *buf, uint16_
                                                    num_bytes + EXTFLASH_CMDADDR_SIZE,
                                                    (void *)(gExtflashControl.spi_recv_buffer),
                                                    0,
-                                                   &(gExtflashControl.send_complete),
-                                                   false);
+                                                   &(gExtflashControl.send_complete));
     }
     else
     {

--- a/karman-avionics/src/drivers/n25q_512.c
+++ b/karman-avionics/src/drivers/n25q_512.c
@@ -19,8 +19,8 @@
 #define EXTFLASH_MOSI (FLASH_MOSI) /**< Internal definition of flash MOSI */
 #define EXTFLASH_MISO (FLASH_MISO) /**< Internal definition of flash MISO */
 #define EXTFLASH_SCK  (FLASH_SCLK) /**< Internal definition of flash SCLK */
-#define EXTFLASH_SPI (FLASH_SPI)   /**< Internal definition of flash SPI intstance (actually UART) */
-#define EXTFLASH_SPI_PORT (FLASH_PORT) /**< Internal defintion of flash SPI port */
+#define EXTFLASH_SPI (FLASH_SPI)   /**< Internal definition of flash SPI instance (actually UART) */
+#define EXTFLASH_SPI_PORT (FLASH_PORT) /**< Internal definition of flash SPI port */
 
 #define EXTFLASH_PAGE_MASK      (0x000000FF) /**< Mask to know if data fits in one page. Page size 256 bytes */
 #define EXTFLASH_READ_DATA_CMD  (0x03) /**< Read command */
@@ -29,7 +29,7 @@
 #define EXTFLASH_4BYTEMODE      (0xB7) /**< Config value for 4 byte address mode */
 #define EXTFLASH_PAGE_PROGRAM   (0x02) /**< Page program command. i.e. actually write something. */
 
-#define EXTFLASH_CS_PORT (FLASH_PORT) /**< Internal defintion of chip select port */
+#define EXTFLASH_CS_PORT (FLASH_PORT) /**< Internal definition of chip select port */
 #define EXTFLASH_CS_BM   (FLASH_CS)   /**< Internal definition of chip select pin */
 
 #define EXTFLASH_WREN_LATCH  (1 << 1) /**< Status register mask for write enable */
@@ -41,7 +41,7 @@
 #endif
 
 /**
- * @brief Calcualte Baud control value for USART.
+ * @brief Calculate Baud control value for USART.
  * 
  * See https://github.com/abcminiuser/lufa/blob/master/LUFA/Drivers/Peripheral/XMEGA/SerialSPI_XMEGA.h 
  */
@@ -69,7 +69,7 @@ void init_extflash(void)
     EXTFLASH_SPI.BAUDCTRLA = (uint8_t)(baudrate & 0xFF); /* LSBs of Baud rate value. */
     EXTFLASH_SPI.CTRLA = 0x10; /* RXCINTLVL = 1, other 2 disabled */
     EXTFLASH_SPI.CTRLB = 0x18; /* Enable RX and TX */
-    EXTFLASH_SPI.CTRLC = 0xC6; /* MSB first, mode 0. PMODE, SBMODE, CHSIZE ignored by SPI */
+    EXTFLASH_SPI.CTRLC = 0xC0; /* MSB first, mode 0. PMODE, SBMODE, CHSIZE ignored by SPI */
 
     init_spi_master_service(&extflashSpiMaster, &EXTFLASH_SPI, &EXTFLASH_SPI_PORT, spi_bg_task);
     spi_bg_add_master(&extflashSpiMaster);

--- a/karman-avionics/src/drivers/n25q_512.c
+++ b/karman-avionics/src/drivers/n25q_512.c
@@ -111,7 +111,8 @@ void extflash_initialize_regs(void)
                                            1,
                                            (void *)(gExtflashControl.spi_recv_buffer),
                                            0,
-                                           &(gExtflashControl.send_complete));
+                                           &(gExtflashControl.send_complete),
+                                           false);
 }
 
 /** 
@@ -158,7 +159,8 @@ Bool extflash_read(uint32_t addr, size_t num_bytes, uint8_t *buf, Bool block)
                                                       EXTFLASH_CMDADDR_SIZE,
                                                       (void *)(gExtflashControl.spi_recv_buffer),
                                                       EXTFLASH_CMDADDR_SIZE + num_bytes,
-                                                      &(gExtflashControl.send_complete));
+                                                      &(gExtflashControl.send_complete),
+                                                      false);
             /* Copy data into caller's buffer, ignoring garbage data from sending command */
             memcpy((void *)buf, (void *)(&(gExtflashControl.spi_recv_buffer[5])), num_bytes);
         }
@@ -171,7 +173,8 @@ Bool extflash_read(uint32_t addr, size_t num_bytes, uint8_t *buf, Bool block)
                                     EXTFLASH_CMDADDR_SIZE,
                                     (void *)buf,
                                     num_bytes,
-                                    &(gExtflashControl.send_complete));
+                                    &(gExtflashControl.send_complete),
+                                    false);
 
             gExtflashControl.task_inprog = true;
         }
@@ -243,7 +246,8 @@ Bool extflash_read_status_reg(uint16_t *buf, Bool block)
                                                   1,
                                                   (void *)buf,
                                                   2,
-                                                  &(gExtflashControl.send_complete));
+                                                  &(gExtflashControl.send_complete),
+                                                  false);
     }
     else
     {
@@ -279,7 +283,8 @@ Bool extflash_write_enable(Bool block)
                                                    1,
                                                    (void *)(gExtflashControl.spi_recv_buffer),
                                                    0,
-                                                   &(gExtflashControl.send_complete));
+                                                   &(gExtflashControl.send_complete),
+                                                   false);
 
         /* Keep reading the status regsiter until the write enable is confirmed. No timeout. this is pretty dangerous tbh. */
         do 
@@ -330,7 +335,8 @@ Bool extflash_write_one(uint16_t num_bytes, uint32_t addr, uint8_t *buf, uint16_
                                                    num_bytes + EXTFLASH_CMDADDR_SIZE,
                                                    (void *)(gExtflashControl.spi_recv_buffer),
                                                    0,
-                                                   &(gExtflashControl.send_complete));
+                                                   &(gExtflashControl.send_complete),
+                                                   false);
     }
     else
     {

--- a/karman-avionics/src/drivers/n25q_512.c
+++ b/karman-avionics/src/drivers/n25q_512.c
@@ -173,8 +173,7 @@ Bool extflash_read(uint32_t addr, size_t num_bytes, uint8_t *buf, Bool block)
                                     EXTFLASH_CMDADDR_SIZE,
                                     (void *)buf,
                                     num_bytes,
-                                    &(gExtflashControl.send_complete),
-                                    false);
+                                    &(gExtflashControl.send_complete));
 
             gExtflashControl.task_inprog = true;
         }

--- a/karman-avionics/src/framework/Tasks.c
+++ b/karman-avionics/src/framework/Tasks.c
@@ -27,27 +27,27 @@
 simple_task_t TaskList[] =
 {
     /** Task to maintain connection with USB host */
-    {
-        .taskFreq = TASK_FREQ_1500us,
+    /*{
+        .taskFreq = TASK_FREQ_2ms,
         .lastCount = INITIAL_COUNT,
         .task = USB_task_func,
-    },
+    },*/
     /** Task to check status of global sensor data to see if it's time to
     * perform Pyrotechnics activities */
-    { 
+    /*{ 
         .taskFreq = TASK_FREQ_10ms,
         .lastCount = INITIAL_COUNT,
         .task = check_pyro_task_func,
-    },
+    },*/
     /** Radio task to manage reciept and transfer of messages to and from the RF modules */
-    {
+   /* {
         .taskFreq = TASK_FREQ_10ms,
         .lastCount = INITIAL_COUNT,
         .task = radio_task_func,
-    },
+    },*/
     /** Sensor task to keep track of timings for all sensors and when they need called */
     {
-        .taskFreq = TASK_FREQ_1500us,
+        .taskFreq = TASK_FREQ_2ms,
         .lastCount = INITIAL_COUNT,
         .task = sensor_task_func,
     },

--- a/karman-avionics/src/framework/Tasks.h
+++ b/karman-avionics/src/framework/Tasks.h
@@ -12,18 +12,7 @@
 #define TASKS_H_
 #include <compiler.h>
 
-/** With default settings, system clock runs at 2MHz, and our timer interrupt occurs every
-  * 1000 cycles (see Timer.c). So, Our timer interrupt occurs every 2KHz. This has a period of 1/2KHz = 500us
-  * Background (continuous) tasks run every 500us/while no one else is running.
-  * 10ms tasks run every 10ms, etc. Task priority/order is determined by ordering in the task list.
-*/
-typedef enum task_freq_e {
-    TASK_FREQ_BACKGROUND = 0,   /**< Run every loop */
-    TASK_FREQ_1500us = 3,       /**< Run every 1.5ms */
-    TASK_FREQ_10ms = 20,        /**< Run every 10ms */
-    TASK_FREQ_100ms = 200,      /**< Run every 100ms */
-    TASK_FREQ_1s = 2000,        /**< Run every second */
-} task_freq_enum_t;
+#include "Timer.h"
 
 /** Structure to define a task. */
 typedef struct simple_task_s {

--- a/karman-avionics/src/framework/Timer.c
+++ b/karman-avionics/src/framework/Timer.c
@@ -63,7 +63,7 @@ inline uint32_t get_timer_count(void){
     @brief Sleep for \a millis \a milliseconds
     @param millis The number of milliseconds to wait.
 */
-inline void timer_delay_ms(uint8_t millis)
+void timer_delay_ms(uint8_t millis)
 {
     /** Get the start time and calcualte the duration in counts.
      *  Then, twiddle thumbs until \a millis \a milliseconds have
@@ -71,9 +71,9 @@ inline void timer_delay_ms(uint8_t millis)
      */
     uint32_t timer_begin = get_timer_count();
     uint32_t wait_len = 2*millis;
-    while((get_timer_count() - timer_begin) > wait_len)
+    while((get_timer_count() - timer_begin) < wait_len)
     {
-        asm("");
+        /* Do nothing */
     }
 }
 

--- a/karman-avionics/src/framework/Timer.h
+++ b/karman-avionics/src/framework/Timer.h
@@ -13,10 +13,23 @@
 #include <compiler.h>
 #include <asf.h>
 
-/** 
-Eight MS -- Timer is a 500us interrupt 
+/** With default settings, system clock runs at 2MHz, and our timer interrupt occurs every
+  * 1000 cycles (see Timer.c). So, Our timer interrupt occurs at 5KHz. This has a period of 1/5KHz = 200us
+  * Background (continuous) tasks run every 200us/while no one else is running.
+  * 10ms tasks run every 10ms, etc. Task priority/order is determined by ordering in the task list.
 */
-#define EIGHT_MS (16) 
+typedef enum task_freq_e {
+    TASK_FREQ_BACKGROUND = 0,   /**< Run every loop */
+    TASK_FREQ_2ms = 10,         /**< Run every 2ms */
+    TASK_FREQ_10ms = 50,        /**< Run every 10ms */
+    TASK_FREQ_100ms = 500,      /**< Run every 100ms */
+    TASK_FREQ_1s = 5000,        /**< Run every second */
+} task_freq_enum_t;
+
+/** 
+Eight MS -- Timer is a 200us interrupt 
+*/
+#define EIGHT_MS (40) 
 
 /**
     @brief Callback for the TCC0 interrupt
@@ -44,5 +57,11 @@ uint32_t get_timer_count(void);
     @param millis The number of milliseconds to wait.
 */
 void timer_delay_ms(uint8_t millis);
+
+/**
+    @brief Sleep for \a micros \a microseconds
+    @param micros The number of microseconds to wait.
+*/
+void timer_delay_us(uint32_t micros);
 
 #endif /* TIMER_H_ */

--- a/karman-avionics/src/tasks/RadioTask.c
+++ b/karman-avionics/src/tasks/RadioTask.c
@@ -1,7 +1,7 @@
 /**
  * @file RadioTask.c
  *
- * @brief Radio Task Function and Intialization
+ * @brief Radio Task Function and Initialization
  *
  * Created: 12/4/2016 10:19:36 PM
  *  Author: Andrew Kaster
@@ -55,7 +55,7 @@ void init_radio_task(void)
     RADIO_SPI.BAUDCTRLA = (uint8_t)(baudrate & 0xFF); /* LSBs of Baud rate value. */
     RADIO_SPI.CTRLA = 0x10; /* RXCINTLVL = 1, other 2 disabled */
     RADIO_SPI.CTRLB = 0x18; /* Enable RX and TX */
-    RADIO_SPI.CTRLC = 0xC6; /* MSB first, mode 0. PMODE, SBMODE, CHSIZE ignored by SPI */
+    RADIO_SPI.CTRLC = 0xC0; /* MSB first, mode 0. PMODE, SBMODE, CHSIZE ignored by SPI */
 
     init_spi_master_service(&radioSpiMaster, &RADIO_SPI, &RADIO_SPI_PORT, spi_bg_task);
     spi_bg_add_master(&radioSpiMaster);
@@ -65,7 +65,7 @@ void init_radio_task(void)
 }
 
 /**
- * Runs high level Radio state machine and responsiblities
+ * Runs high level Radio state machine and responsibilities
  *
  * This task receives messages from the sensors and from the control loop, and
  * sends them to the radio. It also receives messages from the radio and 

--- a/karman-avionics/src/tasks/SensorTask.c
+++ b/karman-avionics/src/tasks/SensorTask.c
@@ -61,7 +61,7 @@ void init_sensor_task(void)
     SENSOR_SPI.BAUDCTRLA = (uint8_t)(baudrate & 0xFF); /* LSBs of Baud rate value. */
     SENSOR_SPI.CTRLA = 0x10; /* RXCINTLVL = 1, other 2 disabled */
     SENSOR_SPI.CTRLB = 0x18; /* Enable RX and TX */
-    SENSOR_SPI.CTRLC = 0xC6; /* MSB first, mode 0. PMODE, SBMODE, CHSIZE ignored by SPI */
+    SENSOR_SPI.CTRLC = 0xC0; /* MSB first, mode 0. PMODE, SBMODE, CHSIZE ignored by SPI */
 
     init_spi_master_service(&sensorSpiMaster, &SENSOR_SPI, &SENSOR_SPI_PORT, spi_bg_task);
     spi_bg_add_master(&sensorSpiMaster);

--- a/karman-avionics/src/utils/FlashMem.c
+++ b/karman-avionics/src/utils/FlashMem.c
@@ -74,6 +74,9 @@ void init_flashmem(void)
          */
         memcpy((void *)&gFlashmemCtrl.header, (void *)&header, sizeof(flash_data_hdr_t));
     }
+
+    /* FOR DEBUG ONLY */
+    headerStatus = flashmem_verify_header(&header);
 }
 
 /** @brief Write the header to flash

--- a/karman-avionics/src/utils/Spi_service.c
+++ b/karman-avionics/src/utils/Spi_service.c
@@ -65,6 +65,42 @@ Bool init_spi_master_service(spi_master_t *masterObj, USART_t *regSet, PORT_t *p
 }
 
 /**
+ * @brief wrapper for spi_master_enqueue internal with keep_cs_low equal to false
+ *
+ * @param spi_interface The SPI master object to use
+ * @param csInfo Chip select information for the hardware device to contact
+ * @param sendBuff Caller's buffer containing the data to be sent out
+ * @param sendLen Number of bytes to send
+ * @param[out] recvBuff Caller's buffer to store response from device into
+ * @param recvLen Number of bytes to receive
+ * @param complete Flag to set true when the transaction is complete
+ * @param keep_cs_low Flag to determine if we should disable pulling the CS high after the transaction is finished. WARNING: The caller will be required to pull the CS high again or the SPI interface will be broken!!!
+ * @return True on success, false on failure
+ *
+ * The queue is wrapping, and so the array acts like a ring buffer
+ * This makes detecting collisions a lot more fun. A lot of care is taken.
+ * If front and back are the same, this can cause issues. Adding a new entry
+ * when there is still an old entry there is bad. So, we check the valid flag
+ * of the entry indexed by back. If it's valid, we can't add a new one. back 
+ * will always point to the last entry in the queue upon entry to this function.
+ * If there are no entries, back and front are the same. If there are three entries, 
+ * then back will be the index for the last entry. So to create a new entry at the
+ * back of the queue, we check if back + 1 is empty. We only want to update back
+ * if we successfully add an entry.
+ */
+
+Bool spi_master_enqueue(spi_master_t *spi_interface,
+chip_select_info_t *csInfo,
+volatile void *sendBuff,
+uint16_t sendLen,
+volatile void *recvBuff,
+uint16_t recvLen,
+volatile Bool *complete) {
+	
+	return spi_master_enqueue_internal(spi_interface, csInfo, sendBuff, sendLen, recvBuff, recvLen, complete, false);
+}
+
+/**
  * @brief Push function for queue.
  *
  * @param spi_interface The SPI master object to use
@@ -88,7 +124,7 @@ Bool init_spi_master_service(spi_master_t *masterObj, USART_t *regSet, PORT_t *p
  * back of the queue, we check if back + 1 is empty. We only want to update back
  * if we successfully add an entry.
  */
-Bool spi_master_enqueue(spi_master_t *spi_interface,
+Bool spi_master_enqueue_internal(spi_master_t *spi_interface,
                             chip_select_info_t *csInfo,
                             volatile void *sendBuff,
                             uint16_t sendLen,
@@ -336,7 +372,7 @@ Bool spi_master_blocking_send_request(spi_master_t *spi_interface,
     /** In the future we might add a timeout..? */
     Bool retVal = true;
 
-    spi_master_enqueue(spi_interface, csInfo, sendBuff, sendLen, recvBuff, recvLen, complete, keep_cs_low);
+    spi_master_enqueue_internal(spi_interface, csInfo, sendBuff, sendLen, recvBuff, recvLen, complete, keep_cs_low);
     spi_master_initate_request(spi_interface);
 
     while((*complete) != true)

--- a/karman-avionics/src/utils/Spi_service.c
+++ b/karman-avionics/src/utils/Spi_service.c
@@ -31,14 +31,12 @@
 /** The size of every SPI master's queue */
 #define SPI_MASTER_QUEUE_SIZE (SPI_MASTER_QUEUE_DEPTH*sizeof(spi_request_t))
 
-volatile static Bool raiseCS = true;
-
 /** 
- * @brief Intialize an SPI master object
+ * @brief Initialize an SPI master object
  * @return bool - Whether or not it initialized successfully.
  * 
  * @param masterObj -  Spi master object for a given SPI bus
- * @param regSet - The hardware peripheral assocaited with the SPI bus
+ * @param regSet - The hardware peripheral associated with the SPI bus
  * @param port - The port this is being initialized on.
  * @param taskName - A function to be run in the background that process its queue
  * initializes an SPI master servicer object
@@ -131,9 +129,9 @@ Bool spi_master_enqueue(spi_master_t *spi_interface,
         newRequest->csInfo.pinBitMask = csInfo->pinBitMask;
 
         if(keep_cs_low) {
-            raiseCS = false;
+            newRequest->raise_cs = false;
         }else {
-            raiseCS = true;
+            newRequest->raise_cs = true;
         }
 
         newRequest->sendBuff = sendBuff;
@@ -290,7 +288,7 @@ void spi_master_ISR(spi_master_t *spi_interface)
          * There are a few special cases (i.e. Altimeter Reset procedure) that
          * require it to be held low.
         */
-        if(raiseCS){
+        if(currRequest->raise_cs){
             spi_master_finish_request(currRequest);
         }
         /** Inform the initiator that the request has completed*/

--- a/karman-avionics/src/utils/Spi_service.h
+++ b/karman-avionics/src/utils/Spi_service.h
@@ -92,37 +92,29 @@ Bool init_spi_master_service(spi_master_t *master,
 
 
 /**
- * @brief wrapper for spi_master_enqueue internal with keep_cs_low equal to false
+ * @brief wrapper for spi_master_enqueue_internal with keep_cs_low equal to false
  *
- * @param spi_interface The SPI master object to use
- * @param csInfo Chip select information for the hardware device to contact
- * @param sendBuff Caller's buffer containing the data to be sent out
- * @param sendLen Number of bytes to send
- * @param[out] recvBuff Caller's buffer to store response from device into
- * @param recvLen Number of bytes to receive
- * @param complete Flag to set true when the transaction is complete
- * @param keep_cs_low Flag to determine if we should disable pulling the CS high after the transaction is finished. WARNING: The caller will be required to pull the CS high again or the SPI interface will be broken!!!
- * @return True on success, false on failure
- *
- * The queue is wrapping, and so the array acts like a ring buffer
- * This makes detecting collisions a lot more fun. A lot of care is taken.
- * If front and back are the same, this can cause issues. Adding a new entry
- * when there is still an old entry there is bad. So, we check the valid flag
- * of the entry indexed by back. If it's valid, we can't add a new one. back 
- * will always point to the last entry in the queue upon entry to this function.
- * If there are no entries, back and front are the same. If there are three entries, 
- * then back will be the index for the last entry. So to create a new entry at the
- * back of the queue, we check if back + 1 is empty. We only want to update back
- * if we successfully add an entry.
  */
 
 Bool spi_master_enqueue(spi_master_t *spi_interface,
-chip_select_info_t *csInfo,
-volatile void *sendBuff,
-uint16_t sendLen,
-volatile void *recvBuff,
-uint16_t recvLen,
-volatile Bool *complete);
+                        chip_select_info_t *csInfo,
+                        volatile void *sendBuff,
+                        uint16_t sendLen,
+                        volatile void *recvBuff,
+                        uint16_t recvLen,
+                        volatile Bool *complete);
+
+/**
+ * @brief wrapper for spi_master_enqueue_internal with keep_cs_low equal to true
+ *
+ */
+Bool spi_master_enqueue_cslow(spi_master_t *spi_interface,
+                              chip_select_info_t *csInfo,
+                              volatile void *sendBuff,
+                              uint16_t sendLen,
+                              volatile void *recvBuff,
+                              uint16_t recvLen,
+                              volatile Bool *complete);
 
 /**
  * @brief Push function for queue.
@@ -201,7 +193,6 @@ Bool spi_master_initate_request(spi_master_t *spi_interface);
  * @param[out] recvBuff Caller's buffer to store response from device into
  * @param recvLen Number of bytes to receive
  * @param complete Flag to set true when the transaction is complete
- * @param keep_cs_low Flag to determine if we should disable pulling the CS high after the transaction is finished. WARNING: The caller will be required to pull the CS high again or the SPI interface will be broken!!!
  * @return True on success, false on failure
  *
  *
@@ -215,8 +206,35 @@ Bool spi_master_blocking_send_request(spi_master_t *spi_interface,
                                  uint16_t sendLen,
                                  volatile void *recvBuff,
                                  uint16_t recvLen,
-                                 volatile Bool *complete,
-                                 Bool keep_cs_low);
+                                 volatile Bool *complete);
+
+/**
+ * @brief Send a request, but block the whole time while waiting for it to finish
+ *
+ * @param spi_interface The SPI master object to use
+ * @param csInfo Chip select information for the hardware device to contact
+ * @param sendBuff Caller's buffer containing the data to be sent out
+ * @param sendLen Number of bytes to send
+ * @param[out] recvBuff Caller's buffer to store response from device into
+ * @param recvLen Number of bytes to receive
+ * @param complete Flag to set true when the transaction is complete
+ * @return True on success, false on failure
+ *
+ * WARNING: This function will set the flag keep_cs_low that determines if we should
+ * disable pulling the CS high after the transaction is finished.
+ * WARNING: The caller is required to pull the CS high again or the SPI interface will be broken!!!
+ *
+ * Instead of enqueueing a request and waiting for the SPI Background routine to
+ * start it up, enqueue a request, start it up yourself, and then sit and wait for the
+ * complete boolean to indicate it's done.
+*/
+Bool spi_master_blocking_send_req_cslow(spi_master_t *spi_interface,
+                                 chip_select_info_t *csInfo,
+                                 volatile void *sendBuff,
+                                 uint16_t sendLen,
+                                 volatile void *recvBuff,
+                                 uint16_t recvLen,
+                                 volatile Bool *complete);
 
 /** Pull the chip select pin high to de-select the device */
 #define spi_master_finish_request(reqPtr)       (reqPtr->csInfo.csPort->OUTSET = reqPtr->csInfo.pinBitMask)

--- a/karman-avionics/src/utils/Spi_service.h
+++ b/karman-avionics/src/utils/Spi_service.h
@@ -97,6 +97,7 @@ Bool init_spi_master_service(spi_master_t *master,
  * @param[out] recvBuff Caller's buffer to store response from device into
  * @param recvLen Number of bytes to receive
  * @param complete Flag to set true when the transaction is complete
+ * @param keep_cs_low Flag to determine if we should disable pulling the CS high after the transaction is finished. WARNING: The caller will be required to pull the CS high again or the SPI interface will be broken!!!
  * @return True on success, false on failure
  *
  * The queue is wrapping, and so the array acts like a ring buffer
@@ -116,7 +117,8 @@ Bool spi_master_enqueue(spi_master_t *spi_interface,
                         uint16_t sendLen,
                         volatile void *recvBuff,
                         uint16_t recvLen,
-                        volatile Bool *complete);
+                        volatile Bool *complete,
+                        Bool keep_cs_low);
 
 /** 
  * @brief Dequeue an item from an SPI master's queue
@@ -162,6 +164,7 @@ Bool spi_master_initate_request(spi_master_t *spi_interface);
  * @param[out] recvBuff Caller's buffer to store response from device into
  * @param recvLen Number of bytes to receive
  * @param complete Flag to set true when the transaction is complete
+ * @param keep_cs_low Flag to determine if we should disable pulling the CS high after the transaction is finished. WARNING: The caller will be required to pull the CS high again or the SPI interface will be broken!!!
  * @return True on success, false on failure
  *
  *
@@ -170,12 +173,13 @@ Bool spi_master_initate_request(spi_master_t *spi_interface);
  * complete boolean to indicate it's done.
 */
 Bool spi_master_blocking_send_request(spi_master_t *spi_interface,
-                                      chip_select_info_t *csInfo,
-                                      volatile void *sendBuff,
-                                      uint16_t sendLen,
-                                      volatile void *recvBuff,
-                                      uint16_t recvLen,
-                                      volatile Bool *complete);
+                                 chip_select_info_t *csInfo,
+                                 volatile void *sendBuff,
+                                 uint16_t sendLen,
+                                 volatile void *recvBuff,
+                                 uint16_t recvLen,
+                                 volatile Bool *complete,
+                                 Bool keep_cs_low);
 
 /** Pull the chip select pin high to de-select the device */
 #define spi_master_finish_request(reqPtr)       (reqPtr->csInfo.csPort->OUTSET = reqPtr->csInfo.pinBitMask)

--- a/karman-avionics/src/utils/Spi_service.h
+++ b/karman-avionics/src/utils/Spi_service.h
@@ -50,9 +50,10 @@ typedef struct
   volatile uint8_t      bytesSent;  /**< How many bytes have already been sent */
   volatile void         *recvBuff;  /**< Buffer to store the result in */
   uint16_t               recvLen;   /**< How many bytes to expect from the device */
-  volatile uint8_t      bytesRecv;  /**< How many bytes have actually been recieved */
+  volatile uint8_t      bytesRecv;  /**< How many bytes have actually been received */
   volatile Bool         *complete;  /**< Complete flag */
   Bool                  valid;      /**< Valid flag. Is this a valid request? */
+  Bool                  raise_cs;   /**< */
 } spi_request_t;
 
 /** @brief Struct to define the SPI interface to use. 


### PR DESCRIPTION
Includes changes to make all SPI interfaces use Mode 0 (probably a really really good thing to do, since who uses Mode 3? Nobody, that's who).

Includes changes to make the base timer tick 200us instead of 500us.

Includes fixes to Timer.c that makes the delay_ms function work properly.

Includes bugfixes in SPI Library, and a few wrappers for SPI Enqueue that allow for requests that don't raise the chip select after the request is complete and making the application do this. 
NOTE: This is super dangerous outside of initialization, and should really never be done there.

Resolves #10